### PR TITLE
Create docker package serving materials

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -70,7 +70,7 @@
     "plane-spheres-materials": {
       "flake": false,
       "locked": {
-        "lastModified": 1737589702,
+        "lastModified": 1738047650,
         "narHash": "sha256-fJXDww/6r7m6EnzXjLR42C2jWANqdxoWTENLYEt9SDg=",
         "path": "/home/ryanl/git-repos/godot-projects/planespheres/game/materials/",
         "type": "path"
@@ -80,12 +80,26 @@
         "type": "path"
       }
     },
+    "plane-spheres-materials-tar": {
+      "flake": false,
+      "locked": {
+        "lastModified": 1,
+        "narHash": "sha256-f7cTyTGmLqkSGH7AAKuhc9zgqXsm3vu29n1sDEqLqE8=",
+        "type": "tarball",
+        "url": "https://www.planespheres.com/materials/plane-spheres-materials.tar.gz"
+      },
+      "original": {
+        "type": "tarball",
+        "url": "https://www.planespheres.com/materials/plane-spheres-materials.tar.gz"
+      }
+    },
     "root": {
       "inputs": {
         "flake-parts": "flake-parts",
         "nixpkgs": "nixpkgs",
         "nuget-packageslock2nix": "nuget-packageslock2nix",
-        "plane-spheres-materials": "plane-spheres-materials"
+        "plane-spheres-materials": "plane-spheres-materials",
+        "plane-spheres-materials-tar": "plane-spheres-materials-tar"
       }
     }
   },

--- a/flake.nix
+++ b/flake.nix
@@ -117,6 +117,9 @@
         packages.plane-spheres-materials-tar = pkgs.callPackage ./pkgs/plane-spheres-materials-tar.nix {
             inherit inputs;
         };
+
+        packages.website-image = pkgs.callPackage ./pkgs/website-image.nix {
+            website = self'.packages.website;
         };
 
         # use 'nix fmt' before committing changes in git

--- a/flake.nix
+++ b/flake.nix
@@ -8,9 +8,7 @@
     # use 'nix flake update' to bump the version of nixpkgs used
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
 
-    # This input represents large static files I don't want in the repo
-    # I plan on hosting these files using the same domain hosting the web build
-    # TODO: change url to endpoint that servers static files
+    # WARN: in order to build the website image you must have the uncompressed assets for the game
     plane-spheres-materials = {
       url = "path:/home/ryanl/git-repos/godot-projects/planespheres/game/materials/";
       flake = false;
@@ -106,6 +104,11 @@
         packages.website = pkgs.callPackage ./pkgs/website.nix {
           inherit inputs;
           web-build = self'.packages.web-build;
+
+        # creates a tar ball of our local game assets/materials
+        packages.plane-spheres-materials-tar = pkgs.callPackage ./pkgs/plane-spheres-materials-tar.nix {
+            inherit inputs;
+        };
         };
 
         # use 'nix fmt' before committing changes in git

--- a/flake.nix
+++ b/flake.nix
@@ -103,6 +103,7 @@
           plane-spheres-materials-tar = inputs.plane-spheres-materials-tar;
           version = "1.0.0";
           pname = "index";
+          exportMode = "debug";
           src = ./game;
           preset = "Web"; # You need to create this preset in godot
         };

--- a/flake.nix
+++ b/flake.nix
@@ -14,6 +14,12 @@
       flake = false;
     };
 
+    # TODO: I should pull these resource directly from where they are hosted, ie. polyhaven.com
+    plane-spheres-materials-tar = {
+      url = "https://www.planespheres.com/materials/plane-spheres-materials.tar.gz";
+      flake = false;
+    };
+
     # helpful tool to manage dotnet nuget dependencies
     nuget-packageslock2nix = {
       url = "github:mdarocha/nuget-packageslock2nix/main";
@@ -79,7 +85,7 @@
           # fetch export templates, provided by godot team to help build
           export_templates = pkgs.godot_4-export-templates;
 
-          plane-spheres-materials = inputs.plane-spheres-materials;
+          plane-spheres-materials-tar = inputs.plane-spheres-materials-tar;
           version = "1.0.0";
           pname = "linux_template";
           src = ./game;
@@ -94,7 +100,7 @@
           # fetch export templates, provided by godot team to help build
           export_templates = pkgs.godot_4-export-templates;
 
-          plane-spheres-materials = inputs.plane-spheres-materials;
+          plane-spheres-materials-tar = inputs.plane-spheres-materials-tar;
           version = "1.0.0";
           pname = "index";
           src = ./game;
@@ -104,6 +110,8 @@
         packages.website = pkgs.callPackage ./pkgs/website.nix {
           inherit inputs;
           web-build = self'.packages.web-build;
+          plane-spheres-materials-tar = self'.packages.plane-spheres-materials-tar;
+        };
 
         # creates a tar ball of our local game assets/materials
         packages.plane-spheres-materials-tar = pkgs.callPackage ./pkgs/plane-spheres-materials-tar.nix {

--- a/pkgs/linux-build.nix
+++ b/pkgs/linux-build.nix
@@ -5,7 +5,7 @@
   fontconfig,
   copyDesktopItems,
   export_templates,
-  plane-spheres-materials,
+  plane-spheres-materials-tar,
   pname,
   version,
   src,
@@ -41,7 +41,7 @@
 
       ln -s ${exportTemplates} /build/.local/share/godot/export_templates/4.3.stable
 
-      ln -s ${plane-spheres-materials} /build/game/materials
+      ln -s ${plane-spheres-materials-tar}/store/*source/ /build/game/materials
 
       mkdir -p $out/share/${pname}
       godot4 --headless --export-${exportMode} "${preset}" \

--- a/pkgs/plane-spheres-materials-tar.nix
+++ b/pkgs/plane-spheres-materials-tar.nix
@@ -1,0 +1,15 @@
+{
+  inputs,
+  runCommandWith,
+}: let
+  # materials/assets used during the building of plane-spheres
+  plane-spheres-materials = inputs.plane-spheres-materials;
+in
+  runCommandWith {
+    name = "plane-spheres-materials-tar";
+  } ''
+    mkdir -p $out
+    tar -czvf plane-spheres-materials.tar.gz ${plane-spheres-materials}
+    mv plane-spheres-materials.tar.gz $out
+  ''
+

--- a/pkgs/web-build.nix
+++ b/pkgs/web-build.nix
@@ -5,7 +5,7 @@
   fontconfig,
   copyDesktopItems,
   export_templates,
-  plane-spheres-materials,
+  plane-spheres-materials-tar,
   pname,
   version,
   src,
@@ -36,7 +36,7 @@
 
       ln -s ${exportTemplates} /build/.local/share/godot/export_templates/4.3.stable
 
-      ln -s ${plane-spheres-materials} /build/game/materials
+      ln -s ${plane-spheres-materials-tar}/store/*source/ /build/game/materials
 
       mkdir -p $out/share/${pname}
       godot4 --headless --export-${exportMode} "${preset}" \

--- a/pkgs/website-image.nix
+++ b/pkgs/website-image.nix
@@ -1,0 +1,32 @@
+{
+  website,
+  dockerTools,
+  lib,
+  buildEnv,
+  runtimeShell,
+}: let
+  image = dockerTools.buildImage {
+    name = lib.strings.concatStrings ["rynplynch/" website.pname];
+    tag = website.version;
+
+    copyToRoot = buildEnv {
+      name = "image-root";
+      paths = [website];
+      pathsToLink = ["/bin"];
+    };
+
+    runAsRoot = ''
+      #!${runtimeShell}
+      mkdir -p /tmp
+    '';
+
+    config = {
+      Cmd = [website.pname];
+
+      ExposedPorts = {
+        "${website.port}/tcp" = {};
+      };
+    };
+  };
+in
+  image

--- a/pkgs/website.nix
+++ b/pkgs/website.nix
@@ -4,6 +4,7 @@
   system,
   inputs,
   web-build,
+  plane-spheres-materials-tar,
 }: let
   # started configuration attributes for dotnet projects
   pname = "planespheres-website";
@@ -48,7 +49,10 @@
       "--set ASPNETCORE_URLS http://+:${port}/"
       # Allows our server to serve the static files that make up the web build
       "--set WEB_BUILD_PATH ${web-build}/share/${web-build.pname}"
+      # Allows our server to serve assets used in the building of our game
+      "--set MATERIALS_PATH ${plane-spheres-materials-tar}"
     ];
   };
 in
   planespheres-website
+

--- a/website/Program.cs
+++ b/website/Program.cs
@@ -64,8 +64,10 @@ public class Startup
         {
             // Point to the web build in the nix-store
             webBuildProvider = new PhysicalFileProvider(webBuildPath);
+        }
         // Otherwise
-        }else{
+        else
+        {
             //point to a backup build in wwwroot/game, helpful for development
             webBuildProvider = new PhysicalFileProvider(env.WebRootPath + "/game");
         }
@@ -78,25 +80,25 @@ public class Startup
 
         // serve static files and pass in options
         app.UseStaticFiles(new StaticFileOptions
-                {
-                // Server static files using our web build provider
-                FileProvider = webBuildProvider,
+        {
+            // Server static files using our web build provider
+            FileProvider = webBuildProvider,
 
-                // The endpoint mapping to our web build directory
-                RequestPath = new PathString("/web-build"),
+            // The endpoint mapping to our web build directory
+            RequestPath = new PathString("/web-build"),
 
-                // Make sure they are served with the right MIME type
-                ContentTypeProvider = godotContentTypes,
+            // Make sure they are served with the right MIME type
+            ContentTypeProvider = godotContentTypes,
 
-                // before serving the files make changes to the response
-                OnPrepareResponse = ctx =>
-                {
+            // before serving the files make changes to the response
+            OnPrepareResponse = ctx =>
+            {
                 // headers that are required while serving Godot web-build
                 ctx.Context.Response.Headers.Append("Cross-Origin-Opener-Policy", "same-origin");
                 ctx.Context.Response.Headers.Append("Cross-Origin-Embedder-Policy", "require-corp");
                 ctx.Context.Response.Headers.Append("Access-Control-Allow-Origin", "*");
-                }
-                });
+            }
+        });
 
         // TODO: Remove this. Here just for debugging, helps me confirm web build is being served
         app.UseDirectoryBrowser(new DirectoryBrowserOptions

--- a/website/Program.cs
+++ b/website/Program.cs
@@ -107,6 +107,26 @@ public class Startup
             RequestPath = new PathString("/look")
         });
 
+        // Path to materials/assets used to build plane-spheres
+        var materialsPath = System.Environment.GetEnvironmentVariable("MATERIALS_PATH");
+
+        // If that path exits serve it
+        if (materialsPath is not null)
+        {
+            // Point to the data in the nix-store
+            var materialsFileProvider = new PhysicalFileProvider(materialsPath);
+
+            // serve static files and pass in options
+            app.UseStaticFiles(new StaticFileOptions
+            {
+                // Server static files using our web build provider
+                FileProvider = materialsFileProvider,
+
+                // The endpoint mapping to our web build directory
+                RequestPath = new PathString("/materials"),
+            });
+        }
+
         // serves /wwwroot
         app.UseStaticFiles();
 

--- a/website/Program.cs
+++ b/website/Program.cs
@@ -102,10 +102,10 @@ public class Startup
 
         // TODO: Remove this. Here just for debugging, helps me confirm web build is being served
         app.UseDirectoryBrowser(new DirectoryBrowserOptions
-                {
-                FileProvider = webBuildProvider,
-                RequestPath = new PathString("/look")
-                });
+        {
+            FileProvider = webBuildProvider,
+            RequestPath = new PathString("/look")
+        });
 
         // serves /wwwroot
         app.UseStaticFiles();


### PR DESCRIPTION
Serve assets via a docker image for the dotnet website. Our linux and web builds now use the flake input that pulls the material assets from the live planespheres.com site. This allows for other machines to perform 'nix run github:rynplynch/planespheres'. However, they can not build the docker image that servers these static files without having the uncompressed materials in the documented location in the plane-spheres-materials flake input.