### PR TITLE
Dotnet generates this css file. Must match .csproj file.

### DIFF
--- a/website/Views/Shared/_Layout.cshtml
+++ b/website/Views/Shared/_Layout.cshtml
@@ -7,7 +7,7 @@
     <script type="importmap"></script>
     <link rel="stylesheet" href="~/lib/bootstrap/dist/css/bootstrap.min.css" />
     <link rel="stylesheet" href="~/css/site.css" asp-append-version="true" />
-    <link rel="stylesheet" href="~/planespheres.styles.css" asp-append-version="true" />
+    <link rel="stylesheet" href="~/planespheres-website.styles.css" asp-append-version="true" />
 </head>
 <body>
     <header>


### PR DESCRIPTION
Fixed bug that would cause css to not be correctly applied